### PR TITLE
Replaced deprecated generate() method

### DIFF
--- a/library/src/main/java/com/etiennelawlor/imagegallery/library/view/PaletteTransformation.java
+++ b/library/src/main/java/com/etiennelawlor/imagegallery/library/view/PaletteTransformation.java
@@ -48,7 +48,7 @@ public final class PaletteTransformation implements Transformation {
     //# Transformation Contract
     @Override
     public final Bitmap transform(Bitmap source) {
-        final Palette palette = Palette.generate(source);
+        final Palette palette = Palette.from(source).generate();
         CACHE.put(source, palette);
         return source;
     }


### PR DESCRIPTION
generate() method for creating Palette is now deprecated. Source [here](http://developer.android.com/reference/android/support/v7/graphics/Palette.html#generate%28android.graphics.Bitmap%29)
