### PR TITLE
Remove android:allowBackup and android:label from the application tag in AndroidManifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:allowBackup="true" android:label="@string/app_name">
+    <application>
 
         <activity
             android:name="com.etiennelawlor.imagegallery.library.activities.FullScreenImageGalleryActivity"


### PR DESCRIPTION
Applications should handle these types of information on their own. This will also prevent the ManifestMerger from throwing any errors/warnings if an application using this library also has these tags present in its manifest.
